### PR TITLE
Feature/initial trial indexer

### DIFF
--- a/docker-compose/processor.yml
+++ b/docker-compose/processor.yml
@@ -1,5 +1,17 @@
-process:
+index-euctr:
   image: opentrialsrobot/warehouse
-  command: echo 'no-op'
+  command: python -m processor.trials.euctr
+  environment:
+    OPENTRIALS_WAREHOUSE_URL:
+
+index-isrctn:
+  image: opentrialsrobot/warehouse
+  command: python -m processor.trials.isrctn
+  environment:
+    OPENTRIALS_WAREHOUSE_URL:
+
+index-nct:
+  image: opentrialsrobot/warehouse
+  command: python -m processor.trials.nct
   environment:
     OPENTRIALS_WAREHOUSE_URL:

--- a/processor/helpers.py
+++ b/processor/helpers.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+from datetime import datetime
+
+
+def update_trial(conn, mapping, identifier):
+
+    # Get trial
+    trial = None
+    for key, value in mapping.items():
+        if not value:
+            continue
+        trial = conn['trials'].find_one(**{key: value})
+        if trial is not None:
+            break
+
+    # Prepare trial
+    if trial is None:
+        trial = dict(mapping)
+        trial['uuid'] = uuid.uuid4().hex
+        trial['records'] = []
+    trial['updated'] = datetime.now()  # TODO: fix timezone
+    if identifier not in trial['records']:
+        trial['records'].append(identifier)
+
+    # Save to backend
+    conn['trials'].upsert(trial, ['uuid'], ensure=False)

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+from dotenv import load_dotenv
+load_dotenv('.env')
+
+
+WAREHOUSE_URL = os.environ['OPENTRIALS_WAREHOUSE_URL']

--- a/processor/trials/euctr.py
+++ b/processor/trials/euctr.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import dataset
+import sqlalchemy as sa
+from collections import OrderedDict
+
+from .. import helpers
+from .. import settings
+
+
+wh = dataset.connect(settings.WAREHOUSE_URL)
+
+
+for item in wh['euctr']:
+
+    # Log processed item
+    print('Processing: %s' % item['eudract_number_with_country'])
+
+    # Create mapping
+    mapping = OrderedDict()
+    mapping['isrctn_id'] = None
+    mapping['euctr_id'] = item['eudract_number']
+    mapping['isrctn_id'] = None
+    mapping['scientific_title'] = item['full_title_of_the_trial']
+
+    helpers.update_trial(
+        conn=wh,
+        mapping=mapping,
+        identifier='euctr::%s' % item['meta_uuid'])

--- a/processor/trials/isrctn.py
+++ b/processor/trials/isrctn.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import dataset
+import sqlalchemy as sa
+from collections import OrderedDict
+
+from .. import helpers
+from .. import settings
+
+
+wh = dataset.connect(settings.WAREHOUSE_URL)
+
+
+for item in wh['isrctn']:
+
+    # Log processed item
+    print('Processing: %s' % item['isrctn_id'])
+
+    # Create mapping
+    mapping = OrderedDict()
+    mapping['nct_id'] = item['clinicaltrialsgov_number']
+    mapping['euctr_id'] = None
+    mapping['isrctn_id'] = item['isrctn_id']
+    mapping['scientific_title'] = item['scientific_title']
+
+    helpers.update_trial(
+        conn=wh,
+        mapping=mapping,
+        identifier='euctr::%s' % item['meta_uuid'])

--- a/processor/trials/isrctn.py
+++ b/processor/trials/isrctn.py
@@ -30,4 +30,4 @@ for item in wh['isrctn']:
     helpers.update_trial(
         conn=wh,
         mapping=mapping,
-        identifier='euctr::%s' % item['meta_uuid'])
+        identifier='isrctn::%s' % item['meta_uuid'])

--- a/processor/trials/nct.py
+++ b/processor/trials/nct.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import dataset
+import sqlalchemy as sa
+from collections import OrderedDict
+
+from .. import helpers
+from .. import settings
+
+
+wh = dataset.connect(settings.WAREHOUSE_URL)
+
+
+for item in wh['nct']:
+
+    # Log processed item
+    print('Processing: %s' % item['nct_id'])
+
+    # Create mapping
+    mapping = OrderedDict()
+    mapping['nct_id'] = item['nct_id']
+    mapping['euctr_id'] = None
+    mapping['isrctn_id'] = None
+    mapping['scientific_title'] = item['official_title']
+
+    helpers.update_trial(
+        conn=wh,
+        mapping=mapping,
+        identifier='isrctn::%s' % item['meta_uuid'])

--- a/processor/trials/nct.py
+++ b/processor/trials/nct.py
@@ -30,4 +30,4 @@ for item in wh['nct']:
     helpers.update_trial(
         conn=wh,
         mapping=mapping,
-        identifier='isrctn::%s' % item['meta_uuid'])
+        identifier='nct::%s' % item['meta_uuid'])


### PR DESCRIPTION
### Data flow
- indexing processor creates `trials` index in `warehouse` and generates trial uuid
- `mapper` use `trials` index table as entry point to iterate over all `ready-to-map` trials
- the same mechanism could be used for `persons`, `organisations` etc
### Table: `warehouse.trials`

```
    op.create_table('trials',
        sa.Column('uuid', UUID, primary_key=True),
        sa.Column('updated', sa.DateTime(timezone=True), nullable=False),
        # records column stores path to entity instance
        # for person it should be `labels` column like `register::uuid::label/hash`
        # {euctr::2205f8f98fcf4c58b90c9b9c247e8115,isrctn::de7da83caca24318b961853a052a0f87}
        sa.Column('records', ARRAY(sa.Text), nullable=False, unique=True),
        sa.Column('nct_id', sa.Text, unique=True),
        sa.Column('euctr_id', sa.Text, unique=True),
        sa.Column('isrctn_id', sa.Text, unique=True),
        sa.Column('scientific_title', sa.Text, unique=True),
    )
```
