### PR TITLE
FDA Approval History Processor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ AWS_ACCESS_KEY_ID='<access_key>'  # optional
 AWS_SECRET_ACCESS_KEY='<secret_key>'  # optional
 AWS_S3_BUCKET='<bucket>'  # optional
 AWS_S3_REGION='<region>'  # optional
+AWS_S3_CUSTOM_DOMAIN='http://example.org'  # optional
+DOCUMENTCLOUD_USERNAME='<username>'  # optional
+DOCUMENTCLOUD_PASSWORD='<password>'  # optional
+DOCUMENTCLOUD_PROJECT='<project name>'  # optional

--- a/processors/base/config.py
+++ b/processors/base/config.py
@@ -39,6 +39,13 @@ AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', None)
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', None)
 AWS_S3_BUCKET = os.environ.get('AWS_S3_BUCKET', None)
 AWS_S3_REGION = os.environ.get('AWS_S3_REGION', None)
+AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN')
+
+# DocumentCloud
+
+DOCUMENTCLOUD_USERNAME = os.environ.get('DOCUMENTCLOUD_USERNAME')
+DOCUMENTCLOUD_PASSWORD = os.environ.get('DOCUMENTCLOUD_PASSWORD')
+DOCUMENTCLOUD_PROJECT = os.environ.get('DOCUMENTCLOUD_PROJECT')
 
 # Contrib
 

--- a/processors/base/readers/row.py
+++ b/processors/base/readers/row.py
@@ -39,5 +39,9 @@ def read_rows(conn, dataset, table, orderby, bufsize=100, **filter):
             # Fixing hex representation
             for field in ['id', 'meta_id']:
                 if field in row:
-                    row[field] = uuid.UUID(row[field]).hex
+                    try:
+                        row[field] = uuid.UUID(row[field]).hex
+                    except ValueError:
+                        # Ignore errors if ID fields aren't UUIDs
+                        pass
             yield row

--- a/processors/base/writers/__init__.py
+++ b/processors/base/writers/__init__.py
@@ -14,3 +14,4 @@ from .record import write_database_record
 from .source import write_source
 from .trial import write_trial
 from .trial_relationship import write_trial_relationship
+from .document import write_document

--- a/processors/base/writers/document.py
+++ b/processors/base/writers/document.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+from .. import readers
+logger = logging.getLogger(__name__)
+
+
+# Module API
+
+def write_document(conn, document):
+    """Write document to database.
+
+    Args:
+        conn (dict): connection dict
+        document (dict): normalized document data
+
+    Raises:
+        KeyError: if data structure is not valid
+
+    Returns:
+        str/None: object identifier/if not written (skipped)
+
+    """
+    create = False
+
+    # Get slug/read object
+    obj = readers.read_objects(
+        conn, 'documents', first=True,
+        id=document['id']
+    )
+
+    # Create object
+    if not obj:
+        obj = {
+            'id': document['id'],
+        }
+        create = True
+
+    # Update object
+    obj.update({
+        'source_id': document.get('source_id'),
+        'name': document['name'],
+        'type': document['type'],
+        'trial_id': document.get('trial_id'),
+        'fda_approval_id': document.get('fda_approval_id'),
+        'url': document['url'],
+        'documentcloud_url': document.get('documentcloud_url'),
+    })
+
+    # Write object
+    conn['database']['documents'].upsert(obj, ['id'], ensure=False)
+
+    # Log debug
+    logger.debug(
+        'Document - %s: %s',
+        'created' if create else 'updated',
+        document['name'][0:50]
+    )
+
+    return obj['id']

--- a/processors/base/writers/intervention.py
+++ b/processors/base/writers/intervention.py
@@ -39,36 +39,37 @@ def write_intervention(conn, intervention, source_id):
 
     # Get slug/read object
     slug = helpers.slugify_string(name)
-    object = readers.read_objects(conn, 'interventions', first=True, slug=slug)
+    obj = readers.read_objects(conn, 'interventions', first=True, slug=slug)
 
     # Create object
-    if not object:
-        object = {}
-        object['id'] = uuid.uuid4().hex
-        object['created_at'] = timestamp
-        object['slug'] = slug
+    if not obj:
+        obj = {}
+        obj['id'] = uuid.uuid4().hex
+        obj['created_at'] = timestamp
+        obj['slug'] = slug
         create = True
 
     # Write object only for high priority source
     if create or source_id in ['icdpcs', 'fdadl']:
 
         # Update object
-        object.update({
+        obj.update({
             'updated_at': timestamp,
             'source_id': source_id,
             # ---
             'name': name,
-            'type': intervention.get('type', None),
-            'description': intervention.get('description', None),
-            'icdpcs_code': intervention.get('icdpcs_code', None),
-            'ndc_code': intervention.get('ndc_code', None),
+            'type': intervention.get('type'),
+            'description': intervention.get('description'),
+            'icdpcs_code': intervention.get('icdpcs_code'),
+            'ndc_code': intervention.get('ndc_code'),
+            'fda_application_number': intervention.get('fda_application_number'),
         })
 
         # Write object
-        conn['database']['interventions'].upsert(object, ['id'], ensure=False)
+        conn['database']['interventions'].upsert(obj, ['id'], ensure=False)
 
         # Log debug
         logger.debug('Intervention - %s: %s',
             'created' if create else 'updated', name)
 
-    return object['id']
+    return obj['id']

--- a/processors/fda_dap/__init__.py
+++ b/processors/fda_dap/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .processor import process

--- a/processors/fda_dap/processor.py
+++ b/processors/fda_dap/processor.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import uuid
+import hashlib
+import logging
+import requests
+import StringIO
+import PyPDF2
+import boto3
+import documentcloud
+from .. import base
+logger = logging.getLogger(__name__)
+
+
+# Module API
+
+def process(conf, conn):
+    source_id = _create_source(conn)
+    assert source_id is not None
+
+    processor = FDADAPProcessor(conf, conn)
+    for record in base.readers.read_rows(conn, 'warehouse', 'fda_dap', orderby='id'):
+        processor.process_record(record, source_id)
+
+
+def _create_source(conn):
+    source = {
+        'id': 'fda',
+        'name': 'U.S. Food and Drug Administration',
+        'type': 'other',
+    }
+    return base.writers.write_source(conn, source)
+
+
+class FDADAPProcessor(object):
+    INTERVENTIONS_CACHE = {}
+
+    def __init__(self, conf, conn):
+        self._conf = conf
+        self._conn = conn
+
+    def process_record(self, record, source_id):
+        fda_approval = self._write_fda_approval_if_possible(record)
+        if not fda_approval:
+            return
+
+        for document in record['documents']:
+            document_id = self._generate_document_id(document, fda_approval)
+            data = self._find_document(document_id) or {}
+
+            data.update({
+                'id': document_id,
+                'source_id': 'fda',
+                'name': document['name'],
+                'type': 'other',
+                'fda_approval_id': fda_approval['id'],
+            })
+
+            # Merge PDFs and upload to S3
+            if data.get('url') is None:
+                urls = document['urls']
+                logging.debug('Downloading PDFs from %s' % ', '.join(urls))
+                with DownloadAndMergePDFs(urls) as pdf_file:
+                    data['url'] = self._upload_to_s3(pdf_file)
+                    logging.debug('Merged PDF uploaded to: %s' % data['url'])
+
+            # Upload to DocumentCloud
+            if data.get('documentcloud_url') is None:
+                url = data['url']
+                title = '-'.join([
+                    fda_approval['id'],
+                    fda_approval['type'],
+                    document['name']
+                ])
+                dc_url = self._upload_to_documentcloud(url, data, title)
+                logging.debug('PDF uploaded to DocumentCloud: %s' % dc_url)
+                data['documentcloud_url'] = dc_url
+
+            # Save to DB
+            base.writers.write_document(self._conn, data)
+
+    def _write_fda_approval_if_possible(self, fda_approval):
+        '''Creates an FDA Approval row if there's an existing Intervention with
+        the corresponding FDA Application Number in the DB.'''
+
+        application_num = fda_approval['fda_application_num']
+        intervention = self._find_intervention(application_num)
+        if not intervention:
+            msg = "Couldn't find intervention with application %s" % application_num
+            logging.warn(msg)
+            return
+
+        obj = self._find_fda_approval(fda_approval['id'])
+
+        if not obj:
+            obj = {
+                'id': fda_approval['id'],
+            }
+
+        obj.update({
+            'intervention_id': intervention['id'],
+            'supplement_number': fda_approval['supplement_number'],
+            'type': fda_approval['approval_type'],
+            'action_date': fda_approval['action_date'],
+            'notes': fda_approval['notes'],
+        })
+
+        self._conn['database']['fda_approvals'].upsert(obj, ['id'], ensure=False)
+
+        return obj
+
+    def _generate_document_id(self, document, fda_approval):
+        namespace = uuid.UUID(fda_approval['intervention_id'])
+        name = ''.join([fda_approval['id'],
+                        document['name']])
+        return uuid.uuid5(namespace, name.encode('utf-8')).hex
+
+    def _find_intervention(self, fda_application_number):
+        if fda_application_number not in self.INTERVENTIONS_CACHE:
+            intervention = base.readers.read_objects(
+                self._conn, 'interventions', first=True,
+                fda_application_number=fda_application_number
+            )
+            self.INTERVENTIONS_CACHE[fda_application_number] = intervention
+        return self.INTERVENTIONS_CACHE[fda_application_number]
+
+    def _find_document(self, document_id):
+        return base.readers.read_objects(
+            self._conn, 'documents', first=True,
+            id=document_id
+        )
+
+    def _find_fda_approval(self, fda_approval_id):
+        return base.readers.read_objects(
+            self._conn, 'fda_approvals', first=True,
+            id=fda_approval_id
+        )
+
+    def _upload_to_s3(self, fd):
+        s3 = boto3.resource(
+            's3',
+            region_name=self._conf['AWS_S3_REGION'],
+            aws_access_key_id=self._conf['AWS_ACCESS_KEY_ID'],
+            aws_secret_access_key=self._conf['AWS_SECRET_ACCESS_KEY']
+        )
+        bucket_name = self._conf['AWS_S3_BUCKET']
+        checksum = self._calculate_hash(fd)
+        key = 'documents/%s.pdf' % checksum
+
+        s3_custom_domain = self._conf.get('AWS_S3_CUSTOM_DOMAIN')
+        if s3_custom_domain:
+            url = '/'.join([
+                s3_custom_domain,
+                key
+            ])
+        else:
+            url = '/'.join([
+                s3.meta.client.meta.endpoint_url,
+                bucket_name,
+                key,
+            ])
+
+        s3.Bucket(bucket_name).upload_fileobj(fd, key)
+
+        return url
+
+    def _calculate_hash(self, fd):
+        BLOCKSIZE = 65536
+        hasher = hashlib.sha1()
+        for chunk in iter(lambda: fd.read(BLOCKSIZE), b''):
+            hasher.update(chunk)
+        fd.seek(0)
+        return hasher.hexdigest()
+
+    def _upload_to_documentcloud(self, url, document, title):
+        username = self._conf['DOCUMENTCLOUD_USERNAME']
+        password = self._conf['DOCUMENTCLOUD_PASSWORD']
+        project_title = self._conf['DOCUMENTCLOUD_PROJECT']
+
+        client = documentcloud.DocumentCloud(username, password)
+        project, _ = client.projects.get_or_create_by_title(project_title)
+
+        uploaded = client.documents.upload(
+            url,
+            title=title,
+            project=project
+        )
+
+        return uploaded.get_published_url()
+
+
+class DownloadAndMergePDFs(object):
+    def __init__(self, urls):
+        self._urls = urls
+        self._merger = PyPDF2.PdfFileMerger(strict=False)
+
+    def __enter__(self):
+        pdfs = [requests.get(url) for url in self._urls]
+
+        for pdf in pdfs:
+            self._merger.append(StringIO.StringIO(pdf.content))
+
+        output = StringIO.StringIO()
+        self._merger.write(output)
+        output.seek(0)
+
+        return output
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._merger.close()

--- a/processors/fdadl/extractors.py
+++ b/processors/fdadl/extractors.py
@@ -31,6 +31,7 @@ def extract_interventions(record):
             'type': 'drug',
             'description': record['product_type'],
             'ndc_code': record['product_ndc'],
+            'fda_application_number': record.get('fda_application_number'),
         })
 
     return interventions

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ sqlalchemy
 git+git://github.com/frictionlessdata/datapackage-py.git@66fdf7e407b95e1804bea74c6d484df536a4fb3f
 jsontableschema-sql
 boto3
+PyPDF2
+python-documentcloud

--- a/tests/processors/fda_dap/test_processor.py
+++ b/tests/processors/fda_dap/test_processor.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import mock
+import datetime
+import processors.fda_dap.processor as processor
+
+
+class TestFDADAPProcessor(object):
+    @mock.patch('processors.base.writers.write_source')
+    def test_create_source(self, write_mock):
+        expected_source = {
+            'id': 'fda',
+            'name': 'U.S. Food and Drug Administration',
+            'type': 'other',
+        }
+        conn = {}
+        processor._create_source(conn)
+
+        write_mock.assert_called_with(conn, expected_source)
+
+    @mock.patch('processors.fda_dap.processor.FDADAPProcessor._find_intervention')
+    def test_process_record(self, find_intervention_mock):
+        find_intervention_mock.return_value = None
+        conf = {}
+        conn = {}
+        document = {
+            'fda_application_num': 'NDA000000',
+        }
+        proc = processor.FDADAPProcessor(conf, conn)
+        result = proc.process_record(document, 'source_id')
+
+        assert result is None


### PR DESCRIPTION
The data from the `fda_dap` collector contains the approval history of FDA drugs. Each entry in the approval history can have many documents, and each document can be split in multiple PDFs.

For each entry in the `fda_dap` table, we:
1. Save the row's metadata in the `fda_approvals` table (if there's already an approval with the same ID, skip it);
2. For each document
   2.1 Download and merge the PDFs (if there're more than one)
   2.2 Upload to S3
   2.3 Upload to DocumentCloud
   2.4 Save to our DB

The way I structured the code is different from the other processors, which is something I'm not very keen on. However, I tried to make the code as clean as possible, and added a few (very few) tests. I couldn't add more tests because most of them would require access to a test database, which would mean configuring the testing infrastructure. This is something I want to do in the future, as our processors will only become more complex, but chosen not to do now.

I also tried to make the code idempotent. The biggest challenge in this was to use natural IDs, so the same ID is always generated for the same entity, and I also use the SHA-1 hash as key to upload to S3.

When you review this, please also review https://github.com/opentrials/collectors/pull/34 and https://github.com/opentrials/api/pull/68, which are its dependencies.

opentrials/opentrials#302
