### PR TITLE
Extract submitting documents do DocumentCloud from FDA_DAP processor

### DIFF
--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -346,6 +346,21 @@ sync-text-from-documentcloud:
   tags:
     - opentrials
 
+send-fda-docs-to-documentcloud:
+  image: okibot/processors
+  command: make start send_fda_docs_to_documentcloud
+  # restart: always
+  environment:
+    WAREHOUSE_URL:
+    DATABASE_URL:
+    EXPLORERDB_URL:
+    LOGGING_URL:
+    DOCUMENTCLOUD_USERNAME:
+    DOCUMENTCLOUD_PASSWORD:
+    DOCUMENTCLOUD_PROJECT:
+  tags:
+    - opentrials
+
 sources-remover:
   image: okibot/processors
   command: make start sources_remover

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,12 @@ sync-text-from-documentcloud:
     file: docker-cloud.yml
   restart: 'no'
 
+send-fda-docs-to-documentcloud:
+  extends:
+    service: send-fda-docs-to-documentcloud
+    file: docker-cloud.yml
+  restart: 'no'
+
 sources-remover:
   extends:
     service: sources-remover

--- a/processors/send_fda_docs_to_documentcloud/__init__.py
+++ b/processors/send_fda_docs_to_documentcloud/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .processor import process

--- a/processors/send_fda_docs_to_documentcloud/processor.py
+++ b/processors/send_fda_docs_to_documentcloud/processor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 def process(conf, conn):
     query = '''
-        SELECT
+        SELECT DISTINCT ON (files.id)
           documents.name,
           files.id,
           files.url,

--- a/processors/send_fda_docs_to_documentcloud/processor.py
+++ b/processors/send_fda_docs_to_documentcloud/processor.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
+import re
 import logging
 import documentcloud
 logger = logging.getLogger(__name__)
@@ -55,11 +56,15 @@ class _SendFDADocsToDocumentCloudProcessor(object):
             doc.delete()
             doc = self._upload_file(the_file)
 
+        application_type = re.findall(r'^[a-zA-Z]+',
+                                      the_file['fda_application_id'])[0]
+
         doc.title = self._generate_title(the_file)
         doc.project = self._project
         doc.access = 'public'
         doc.data = {
             'fda_application': the_file['fda_application_id'],
+            'application_type': application_type,
             'supplement_number': str(the_file['supplement_number']),
             'type': the_file['type'],
             'action_date': the_file['action_date'].isoformat(),

--- a/processors/send_fda_docs_to_documentcloud/processor.py
+++ b/processors/send_fda_docs_to_documentcloud/processor.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import logging
+import documentcloud
+logger = logging.getLogger(__name__)
+
+
+def process(conf, conn):
+    query = '''
+        SELECT
+          documents.name,
+          files.id,
+          files.url,
+          files.sha1,
+          files.documentcloud_id,
+          fda_approvals.supplement_number,
+          fda_approvals.action_date,
+          fda_approvals.fda_application_id,
+          fda_approvals.type
+        FROM documents
+        INNER JOIN files ON documents.file_id = files.id
+        INNER JOIN fda_approvals ON documents.fda_approval_id = fda_approvals.id
+        WHERE documents.fda_approval_id IS NOT NULL
+          AND documents.file_id IS NOT NULL
+        ORDER BY files.id
+    '''
+    processor = _SendFDADocsToDocumentCloudProcessor(conf, conn['database'])
+    for the_file in conn['database'].query(query):
+        try:
+            the_file['id'] = the_file['id'].hex
+            processor.process_file(the_file)
+            logger.debug('Processed file %s' % the_file['id'])
+        except:
+            logger.exception('Failed processing file %s' % the_file['id'])
+
+
+class _SendFDADocsToDocumentCloudProcessor(object):
+    def __init__(self, conf, db):
+        self._conf = conf
+        self._db = db
+
+    def process_file(self, the_file):
+        if the_file.get('documentcloud_id'):
+            doc = self._dc_client.documents.get(the_file['documentcloud_id'])
+        else:
+            doc = self._upload_file(the_file)
+
+        if doc.file_hash and (doc.file_hash != the_file['sha1']):
+            logger.debug('Deleting outdated DocumentCloud doc: %s' % doc.id)
+            doc.delete()
+            doc = self._upload_file(the_file)
+
+        doc.title = self._generate_title(the_file)
+        doc.project = self._project
+        doc.access = 'public'
+        doc.data = {
+            'fda_application': the_file['fda_application_id'],
+            'supplement_number': str(the_file['supplement_number']),
+            'type': the_file['type'],
+            'action_date': the_file['action_date'].isoformat(),
+        }
+
+        doc.save()
+
+        documentcloud_id = doc.id.split('-')[0]
+        if the_file.get('documentcloud_id') != documentcloud_id:
+            the_file['documentcloud_id'] = documentcloud_id
+            self._db['files'].upsert(the_file, ['id'], ensure=False)
+
+    def _upload_file(self, the_file):
+        title = self._generate_title(the_file)
+        doc = self._dc_client.documents.upload(
+            the_file['url'],
+            title=title,
+            project=self._project.id
+        )
+        logger.debug('PDF uploaded to DocumentCloud: %s' % the_file['url'])
+
+        return doc
+
+    def _generate_title(self, the_file):
+        return '-'.join([
+            the_file['fda_application_id'],
+            str(the_file['supplement_number']),
+            the_file['type'],
+            the_file['name']
+        ])
+
+    @property
+    def _project(self):
+        title = self._conf['DOCUMENTCLOUD_PROJECT']
+        project, _ = self._dc_client.projects.get_or_create_by_title(title)
+
+        return project
+
+    @property
+    def _dc_client(self):
+        username = self._conf['DOCUMENTCLOUD_USERNAME']
+        password = self._conf['DOCUMENTCLOUD_PASSWORD']
+
+        return documentcloud.DocumentCloud(username, password)

--- a/processors/send_fda_docs_to_documentcloud/processor.py
+++ b/processors/send_fda_docs_to_documentcloud/processor.py
@@ -66,6 +66,7 @@ class _SendFDADocsToDocumentCloudProcessor(object):
             'fda_application': the_file['fda_application_id'],
             'application_type': application_type,
             'supplement_number': str(the_file['supplement_number']),
+            'name': the_file['name'],
             'type': the_file['type'],
             'action_date': the_file['action_date'].isoformat(),
         }

--- a/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
+++ b/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import mock
+import datetime
+import pytest
+import sqlalchemy
+import documentcloud
+import dataset
+import processors.send_fda_docs_to_documentcloud.processor as processor
+
+SendFDADocsToDocumentCloudProcessor = processor._SendFDADocsToDocumentCloudProcessor
+
+
+class TestSendFDADocsToDocumentCloudProcessor(object):
+    CONF = {
+        'DOCUMENTCLOUD_USERNAME': 'username',
+        'DOCUMENTCLOUD_PASSWORD': 'username',
+        'DOCUMENTCLOUD_PROJECT': 'username',
+    }
+
+    @mock.patch('documentcloud.DocumentCloud')
+    def test_process_file(self, dc_mock, file_stub, conn):
+        doc_mock, project_mock = _setup_documentcloud_mock(dc_mock)
+        doc_mock.file_hash = file_stub['sha1']
+
+        processor = SendFDADocsToDocumentCloudProcessor(self.CONF, conn['database'])
+        processor.process_file(file_stub)
+
+        doc_mock.save.assert_called()
+        assert doc_mock.project == project_mock
+        assert doc_mock.access == 'public'
+        assert doc_mock.data == {
+            'fda_application': file_stub['fda_application_id'],
+            'supplement_number': str(file_stub['supplement_number']),
+            'type': file_stub['type'],
+            'action_date': file_stub['action_date'].isoformat(),
+        }
+
+    @mock.patch('documentcloud.DocumentCloud')
+    def test_doesnt_upload_file_if_it_wasnt_modified(self, dc_mock, file_stub, conn):
+        doc_mock, project_mock = _setup_documentcloud_mock(dc_mock)
+        doc_mock.file_hash = file_stub['sha1']
+
+        processor = SendFDADocsToDocumentCloudProcessor(self.CONF, conn['database'])
+        processor.process_file(file_stub)
+
+        dc_mock().documents.upload.assert_not_called()
+
+    @mock.patch('documentcloud.DocumentCloud')
+    def test_uploads_and_remove_old_file_if_it_was_modified(self, dc_mock, file_stub, conn):
+        doc_mock, project_mock = _setup_documentcloud_mock(dc_mock)
+        doc_mock.file_hash = 'different-hash'
+
+        processor = SendFDADocsToDocumentCloudProcessor(self.CONF, conn['database'])
+        processor.process_file(file_stub)
+
+        doc_mock.delete.assert_called()
+        dc_mock().documents.upload.assert_called()
+
+    @mock.patch('documentcloud.DocumentCloud')
+    def test_doesnt_remove_file_if_it_has_no_file_hash(self, dc_mock, file_stub, conn):
+        '''A recently-uploaded document to DC has no file_hash.'''
+        del file_stub['documentcloud_id']
+        doc_mock, project_mock = _setup_documentcloud_mock(dc_mock)
+        doc_mock.file_hash = None
+
+        processor = SendFDADocsToDocumentCloudProcessor(self.CONF, conn['database'])
+        processor.process_file(file_stub)
+
+        doc_mock.delete.assert_not_called()
+        dc_mock().documents.upload.assert_called()
+
+
+@pytest.fixture
+def file_stub():
+    return {
+        'documentcloud_id': 'dc_id',
+        'sha1': 'sha1',
+        'fda_application_id': 'NDA000000-000',
+        'supplement_number': 0,
+        'type': 'Review',
+        'name': 'Review',
+        'url': 'https://example.org/file.pdf',
+        'action_date': datetime.date(2016, 1, 1),
+    }
+
+
+@pytest.fixture
+def conn():
+    db = dataset.connect('sqlite:///:memory:')
+    _create_str_columns(db['files'], [
+        'documentcloud_id',
+        'sha1',
+        'fda_application_id',
+        'type',
+        'name',
+        'url',
+    ])
+    db['files'].create_column('supplement_number', sqlalchemy.Integer)
+    db['files'].create_column('action_date', sqlalchemy.Date)
+
+    return {
+        'database': db,
+    }
+
+
+def _setup_documentcloud_mock(dc_mock):
+    project_mock = mock.Mock(autospec=documentcloud.Project)
+    dc_mock().projects.get_or_create_by_title.return_value = [project_mock, None]
+
+    doc_mock = mock.Mock(autospec=documentcloud.Document)
+    doc_mock.id = '123456-document-title'
+    dc_mock().documents.get.return_value = doc_mock
+    dc_mock().documents.upload.return_value = doc_mock
+
+    return doc_mock, project_mock
+
+
+def _create_str_columns(table, columns):
+    for column in columns:
+        table.create_column(column, sqlalchemy.String)

--- a/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
+++ b/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
@@ -26,6 +26,7 @@ class TestSendFDADocsToDocumentCloudProcessor(object):
     def test_process_file(self, dc_mock, file_stub, conn):
         doc_mock, project_mock = _setup_documentcloud_mock(dc_mock)
         doc_mock.file_hash = file_stub['sha1']
+        file_stub['fda_application_id'] = 'NDA00000-000'
 
         processor = SendFDADocsToDocumentCloudProcessor(self.CONF, conn['database'])
         processor.process_file(file_stub)
@@ -35,6 +36,7 @@ class TestSendFDADocsToDocumentCloudProcessor(object):
         assert doc_mock.access == 'public'
         assert doc_mock.data == {
             'fda_application': file_stub['fda_application_id'],
+            'application_type': 'NDA',
             'supplement_number': str(file_stub['supplement_number']),
             'type': file_stub['type'],
             'action_date': file_stub['action_date'].isoformat(),

--- a/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
+++ b/tests/processors/send_fda_docs_to_documentcloud/test_processor.py
@@ -38,6 +38,7 @@ class TestSendFDADocsToDocumentCloudProcessor(object):
             'fda_application': file_stub['fda_application_id'],
             'application_type': 'NDA',
             'supplement_number': str(file_stub['supplement_number']),
+            'name': file_stub['name'],
             'type': file_stub['type'],
             'action_date': file_stub['action_date'].isoformat(),
         }


### PR DESCRIPTION
The FDA_DAP processor was responsible for too many things (downloading PDFs, merging PDFs, uploading to S3, submitting to DocumentCloud). If we needed to, say, add more metadata to the documents in DocumentCloud, we'd have to change and run the FDA_DAP processor again, which does all those things (including downloading/merging PDFs), and so is much slower than needed.

This PR extracts the DocumentCloud-specific parts into a separate `send_fda_docs_to_documentcloud` processor, so it's more manageable and can be run quicker.

Fixes opentrials/opentrials#505
